### PR TITLE
Fix pagination issue

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -111,7 +111,7 @@ async function getCatalogUrls(
         })
 
         urls = urls.concat(newUrls)
-        if (meta.pagination.total > meta.pagination.current_page) {
+        if (meta.pagination.total_pages > meta.pagination.current_page) {
             page++
             return getCatalogUrls(type, page, limit, urls)
         } else {


### PR DESCRIPTION
The generator would send X requests for categories where X was the number of categories. X instead should be the number of category _pages_.

Updated the pagination check to look at meta.pagination.total_pages instead of meta.pagination.total.